### PR TITLE
run `terraform get` instead of `terraform init` to avoid unnecessary backend init

### DIFF
--- a/pkg/directory.go
+++ b/pkg/directory.go
@@ -135,7 +135,7 @@ func (d *directory) ensureModules() error {
 	if exist {
 		return nil
 	}
-	initCmd := exec.Command("terraform", "init")
+	initCmd := exec.Command("terraform", "get")
 	initCmd.Dir = d.path
 	initCmd.Stdout = os.Stdout
 	initCmd.Stderr = os.Stderr


### PR DESCRIPTION
This pr should solve #379 