### PR TITLE
bump helm to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/lonegunmanb/terraform-azurerm-schema/v4 v4.34.0
 	github.com/lonegunmanb/terraform-bytebase-schema v0.0.9
 	github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0
-	github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0
+	github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2
 	github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0
 	github.com/lonegunmanb/terraform-local-schema/v2 v2.5.3
 	github.com/lonegunmanb/terraform-modtm-schema v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/lonegunmanb/terraform-bytebase-schema v0.0.9 h1:VnwghcbQLnherQCRHnlaq
 github.com/lonegunmanb/terraform-bytebase-schema v0.0.9/go.mod h1:QGwRX3GwqSDyd5r+2Q2qXtLLKzcGlAN7Y8eDdAcg4Lc=
 github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0 h1:sNVEILMrIqE2UC2jwP7PIYzdWLNPNqOQqBl5Gr7M7zA=
 github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0/go.mod h1:XbKxTdcxNp+tYBN6Pz8Dl2qpoVfvm2DV18YPuP6v1rc=
-github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0 h1:Jrlb7VrXH7y+6lZTtNx3e3KH5fDiC2wHfJsRAR7oR/c=
-github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0/go.mod h1:980t3S4UuBp9yrgpdA5/kMvniOjNgPvamPivaY1hPto=
+github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2 h1:W9F06IO/Xh6AF7JDMtbaWoq3cDxRZVmjgjqy+WUfJnE=
+github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2/go.mod h1:7GkpRpM6OIuNeBZtQz7Tm64gP/C8FdMiVeKOcUB5PeY=
 github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0 h1:BX3hL3y97/Ckd+0ChzYbBUlQh36n/9mAmnXVFisIYQs=
 github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0/go.mod h1:15XANwYuVpPa/1gFSLYKNkRZVIK0uZaqo8WGTLytIxA=
 github.com/lonegunmanb/terraform-local-schema/v2 v2.5.3 h1:FSSLkdzd04pSDqY7qeRkwfvM6vJbCZIn1IE/VCa3TjA=

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -13,7 +13,7 @@ import (
 	azurerm "github.com/lonegunmanb/terraform-azurerm-schema/v4/generated"
 	bytebase "github.com/lonegunmanb/terraform-bytebase-schema/generated"
 	gcp "github.com/lonegunmanb/terraform-google-schema/v6/generated"
-	helm "github.com/lonegunmanb/terraform-helm-schema/v2/generated"
+	helm "github.com/lonegunmanb/terraform-helm-schema/v3/generated"
 	kubernetes "github.com/lonegunmanb/terraform-kubernetes-schema/v2/generated"
 	local "github.com/lonegunmanb/terraform-local-schema/v2/generated"
 	modtm "github.com/lonegunmanb/terraform-modtm-schema/generated"


### PR DESCRIPTION
This pull request updates the dependency for the `terraform-helm-schema` library from version 2 to version 3 across the codebase. This change ensures compatibility with the latest features and fixes provided in the updated library.

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-R20): Updated the `terraform-helm-schema` dependency from `v2.17.0` to `v3.0.2`.
* [`pkg/schema.go`](diffhunk://#diff-fd41d091aea261d3e82f1628f030dae528d700f9e6c9572bb9812d11537edf99L16-R16): Updated the import path for `terraform-helm-schema` to reflect the new major version (`v3`).