### PR TITLE
Added --exclude and improved flag/parameter handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=

--- a/main.go
+++ b/main.go
@@ -3,25 +3,58 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/lonegunmanb/avmfix/pkg"
 )
 
+const (
+	folderFlag      = "folder"
+	excludeFlag     = "exclude"
+	helpFlag        = "help"
+	
+	folderUsage     = "The folder path to scan and apply fixes"
+	excludeUsage    = "Glob matching pattern to exclude files/folders from processing"
+	helpUsage       = "Show help information"
+	
+	errorMessage    = "Error during processing:"
+	successMessage  = "Processing completed successfully"
+)
+
 func main() {
 	var dirPath string
-	flag.StringVar(&dirPath, "folder", "", "The folder path to apply DirectoryAutoFix")
+	var excludePattern string
+	var showHelp bool
+
+	flag.StringVar(&dirPath, folderFlag, "", folderUsage)
+	flag.StringVar(&excludePattern, excludeFlag, "", excludeUsage)
+	flag.BoolVar(&showHelp, helpFlag, false, helpUsage)
+	
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\nOPTIONS:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  %s --folder /path/to/terraform/files \n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s --folder /path/to/terraform/files --exclude '**/test_*.tf'\n", os.Args[0])
+	}
+	
 	flag.Parse()
 
+	if showHelp {
+		flag.Usage()
+		return
+	}
+
 	if dirPath == "" {
-		fmt.Println("Please provide a folder path using the -folder flag.")
-		return
+		flag.Usage()
+		os.Exit(1)
 	}
 
-	err := pkg.DirectoryAutoFix(dirPath)
+	err := pkg.DirectoryAutoFix(dirPath, excludePattern)
 	if err != nil {
-		fmt.Println("Error during DirectoryAutoFix:", err)
-		return
+		fmt.Fprintf(os.Stderr, "%s %v\n", errorMessage, err)
+		os.Exit(1)
 	}
 
-	fmt.Println("DirectoryAutoFix completed successfully.")
+	fmt.Println(successMessage)
 }


### PR DESCRIPTION
## Summary
- Added `--exclude` flag to support glob patterns for excluding files/folders from processing
- Added `--help` to show usage and displays when no parameters are provided
- Support for both `-` and `--` flag syntax

### Technical Details
- Modified `DirectoryAutoFix()` function signature to accept exclude pattern parameter
- Updated `directory.go` to implement file exclusion logic with glob matching
- Enhanced `main.go` with structured constants and better CLI UX

## Test Plan

- [x] Verify tool builds successfully
- [x] Test `--help` flag displays usage information
- [x] Test tool shows help when run without parameters
- [x] Test exclude pattern functionality works with glob patterns
- [x] Verify both `-folder` and `--folder` syntax work correctly
- [x] Confirm error messages are properly displayed to stderr