### PR TITLE
chore: ignore static schema deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/lonegunmanb/terraform-azurerm-schema/*"
+      - dependency-name: "github.com/lonegunmanb/terraform-aws-schema/*"
+      - dependency-name: "github.com/lonegunmanb/terraform-azapi-schema/*"
+      - dependency-name: "github.com/lonegunmanb/terraform-random-schema/*"


### PR DESCRIPTION
Static schema libraries are only used in tests now. The runtime has migrated to tfpluginschema for dynamic schema retrieval via gRPC.

Ignore dependabot updates for:
- github.com/lonegunmanb/terraform-azurerm-schema/*
- github.com/lonegunmanb/terraform-aws-schema/*
- github.com/lonegunmanb/terraform-azapi-schema/*
- github.com/lonegunmanb/terraform-random-schema/*

Supersedes #477 and #480.
